### PR TITLE
Add link to the grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Projects related to Camunda 8 Connectors that are not Connectors themselves.
 * [OpenAPI Connector Template Generator for REST Connector Runtime](https://github.com/camunda-community-hub/openapi-connector-template-generator)
 * [Node.js Connector SDK](https://github.com/camunda-community-hub/connector-sdk-nodejs) - write Connectors in JavaScript / TypeScript for execution in Node.js.
 * [Template Generator for Camunda Connectors](https://github.com/brix-ag/camunda-connector-utils) - generates template JSON from the annotated request class and provides utilities for multi values
-
+* [Connector runtime Grafana dashboard](https://github.com/camunda-community-hub/connectors-grafana-dashboard) - a metrics dashboard for the Connector runtime
 
 # Resources
 


### PR DESCRIPTION
This PR adds a link to the newly created repository with Grafana metrics dashboard for Connector runtime.